### PR TITLE
Add missing fonts packages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,6 +97,11 @@ dpkg_list(
         "zlib1g",
         "libgcrypt20=1.8.4-5",
         "libgpg-error0",
+        "libpng16-16",
+        "libfreetype6",
+        "fonts-dejavu-core",
+        "fontconfig-config",
+        "libfontconfig1",
     ],
     # Takes the first package found: security updates should go first
     # If there was a security fix to a package before the stable release, this will find

--- a/java/BUILD
+++ b/java/BUILD
@@ -24,6 +24,12 @@ docker_build(
         packages["liblz4-1"],
         packages["libgcrypt20"],
         packages["libgpg-error0"],
+        packages["libpng16-16"],
+        packages["libfreetype6"],
+        packages["fonts-dejavu-core"],
+        packages["fontconfig-config"],
+        packages["libexpat1"],
+        packages["libfontconfig1"],
     ],
     stamp = True,
     entrypoint = [


### PR DESCRIPTION
When installing JavaMelody to monitor artifactory JVM, we get NPE for fonts [1], there is already a fix in the GCR/distroless image to address this by adding missing fonts packages:
https://github.com/GoogleContainerTools/distroless/pull/322/files

[1] artifactory | Exception in thread "http-nio-8081-exec-3" java.lang.InternalError: java.lang.reflect.InvocationTargetException
artifactory | at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:86)
artifactory | at java.base/java.security.AccessController.doPrivileged(Native Method)
artifactory | at java.desktop/sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
artifactory | at java.desktop/sun.font.SunFontManager.getInstance(SunFontManager.java:247)
artifactory | at java.desktop/sun.font.FontDesignMetrics.getMetrics(FontDesignMetrics.java:265)
artifactory | at java.desktop/java.awt.Font.getStringBounds(Font.java:2607)
artifactory | at java.desktop/java.awt.Font.getStringBounds(Font.java:2517)
artifactory | at java.desktop/java.awt.Font.getStringBounds(Font.java:2551)
artifactory | at org.jrobin.graph.ImageWorker.getStringWidth(ImageWorker.java:166)
artifactory | at org.jrobin.graph.RrdGraph.getSmallFontCharWidth(RrdGraph.java:594)
artifactory | at org.jrobin.graph.RrdGraph.initializeLimits(RrdGraph.java:319)
artifactory | at org.jrobin.graph.RrdGraph.createGraph(RrdGraph.java:88)
artifactory | at org.jrobin.graph.RrdGraph.(RrdGraph.java:59)
artifactory | at net.bull.javamelody.internal.model.JRobin.graph(JRobin.java:262)
artifactory | at net.bull.javamelody.internal.web.MonitoringController.doGraph(MonitoringController.java:394)
artifactory | at net.bull.javamelody.internal.web.MonitoringController.doReport(MonitoringController.java:192)
artifactory | at net.bull.javamelody.internal.web.MonitoringController.doActionIfNeededAndReport(MonitoringController.java:163)
artifactory | at net.bull.javamelody.MonitoringFilter.doMonitoring(MonitoringFilter.java:408)
artifactory | at net.bull.javamelody.MonitoringFilter.doFilter(MonitoringFilter.java:206)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.artifactory.webapp.servlet.RepoFilter.execute(RepoFilter.java:186)
artifactory | at org.artifactory.webapp.servlet.RepoFilter.doFilter(RepoFilter.java:96)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.artifactory.webapp.servlet.AccessFilter.useAuthentication(AccessFilter.java:427)
artifactory | at org.artifactory.webapp.servlet.AccessFilter.useAnonymousIfPossible(AccessFilter.java:392)
artifactory | at org.artifactory.webapp.servlet.AccessFilter.doFilterInternal(AccessFilter.java:210)
artifactory | at org.artifactory.webapp.servlet.AccessFilter.doFilter(AccessFilter.java:167)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.artifactory.webapp.servlet.RequestFilter.doFilter(RequestFilter.java:77)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.artifactory.webapp.servlet.ArtifactoryCsrfFilter.doFilter(ArtifactoryCsrfFilter.java:74)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:164)
artifactory | at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:80)
artifactory | at org.artifactory.webapp.servlet.SessionFilter.doFilter(SessionFilter.java:62)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.artifactory.webapp.servlet.ArtifactoryFilter.doFilter(ArtifactoryFilter.java:124)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
artifactory | at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
artifactory | at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
artifactory | at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
artifactory | at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
artifactory | at org.apache.catalina.valves.rewrite.RewriteValve.invoke(RewriteValve.java:279)
artifactory | at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
artifactory | at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
artifactory | at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
artifactory | at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
artifactory | at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:800)
artifactory | at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
artifactory | at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:800)
artifactory | at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1471)
artifactory | at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
artifactory | at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
artifactory | at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
artifactory | at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
artifactory | at java.base/java.lang.Thread.run(Thread.java:834)
artifactory | Caused by: java.lang.reflect.InvocationTargetException
artifactory | at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
artifactory | at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
artifactory | at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
artifactory | at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
artifactory | at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:84)
artifactory | ... 61 more
artifactory | Caused by: java.lang.NullPointerException
artifactory | at java.desktop/sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1262)
artifactory | at java.desktop/sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:225)
artifactory | at java.desktop/sun.awt.FontConfiguration.init(FontConfiguration.java:107)
artifactory | at java.desktop/sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:719)
artifactory | at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:367)
artifactory | at java.base/java.security.AccessController.doPrivileged(Native Method)
artifactory | at java.desktop/sun.font.SunFontManager.(SunFontManager.java:312)
artifactory | at java.desktop/sun.awt.FcFontManager.(FcFontManager.java:35)
artifactory | at java.desktop/sun.awt.X11FontManager.(X11FontManager.java:56)
artifactory | ... 66 more