### PR TITLE
JFI-813 - Create $HOME for insight-server users

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,7 +64,7 @@ dpkg_src(
     name = "debian_stretch_local",
     package_prefix = "https://deepscan.jfrog.io/deepscan/debian-local/",
     packages_gz_url = "https://deepscan.jfrog.io/deepscan/debian-local/dists/stretch/main/binary-amd64/Packages.gz",
-    sha256 = "c33c898bcd3573a64169982d1270a07aee6a01996cf22e82ba0cca13251a8418",
+    sha256 = "538d763e5199f6c95abee89239b4d9f70f2d2914c9de52083276caa914702a3e",
 )
 
 dpkg_list(

--- a/base/insight-sh/BUILD
+++ b/base/insight-sh/BUILD
@@ -20,6 +20,7 @@ passwd_entry(
     name = "elasticsearch_user",
     gid = 1000,
     uid = 1000,
+    home = "/home/elasticsearch",
     username = "elasticsearch",
 )
 
@@ -27,6 +28,7 @@ passwd_entry(
     name = "jfmc_user",
     gid = 1050,
     uid = 1050,
+    home = "/home/jfmc",
     username = "jfmc",
 )
 


### PR DESCRIPTION
- For users elasticsearch, jfmc nonexistence of $HOME is creating
myriad permission issues.

- Updated WORKSPACE hash for binary-amd64/Packages.gz from deepscan
updated on 05-12-19