### PR TITLE
JFI-817 - Add home for root user in insight base image

### DIFF
--- a/base/insight-sh/BUILD
+++ b/base/insight-sh/BUILD
@@ -12,6 +12,7 @@ passwd_entry(
     name = "root_user",
     gid = 0,
     uid = 0,
+    home = "/root",
     username = "root",
 )
 


### PR DESCRIPTION
Root user was assuming home at /home this was preventing other users to access their home path 