### PR TITLE
Updates to Rabbitmq v3.8.9 and mods for Openshift Xray

### DIFF
--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -3,16 +3,10 @@
 # JFROG REDHAT UBI PORT TO WORK IN BITNAMI RABBITMQ HELM CHARTS
 
 
-ARG BASE_REGISTRY=registry1.dsop.io
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
-ARG BASE_TAG=8.2
-
 FROM bitnami/rabbitmq:3.8.9-debian-10-r88 as base
 
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
-
-
 FROM registry.access.redhat.com/ubi8
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 LABEL name="JFrog Rabbit MQ" \
       description="JFrog Rabbit MQ image based on the Red Hat Universal Base Image." \
@@ -52,14 +46,14 @@ RUN set -xe && \
 # COPY OVER THE RABBITMQ LICENSES INTO THE FOLDER FOR REDHAT TO SCAN
 COPY --from=base /opt/bitnami /opt/bitnami
 
-RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq
-RUN mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log
-RUN mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && chown -R 1000721001:1000721001 	/var/lib/rabbitmq
-RUN mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq
-RUN mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami
-RUN mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses
-RUN mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses
-RUN mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
+RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq  \
+   && mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log  \
+   && mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && chown -R 1000721001:1000721001 	/var/lib/rabbitmq \
+   && mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq    \
+   && mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami     \
+   && mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses    \
+   && mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses  \
+   && mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
 
 ENV BITNAMI_APP_NAME="rabbitmq" \
     LANG="en_US.UTF-8" \

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -2,7 +2,15 @@
 # https://github.com/bitnami/bitnami-docker-rabbitmq/blob/master/3.8/debian-10/Dockerfile
 # JFROG REDHAT UBI PORT TO WORK IN BITNAMI RABBITMQ HELM CHARTS
 
-FROM bitnami/rabbitmq:3.8.9-debian-10-r20 as base
+
+ARG BASE_REGISTRY=registry1.dsop.io
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
+ARG BASE_TAG=8.2
+
+FROM bitnami/rabbitmq:3.8.9-debian-10-r88 as base
+
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
+
 
 FROM registry.access.redhat.com/ubi8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -12,7 +20,7 @@ LABEL name="JFrog Rabbit MQ" \
       summary="JFrog Rabbit MQ (Red Hat UBI)" \
       com.jfrog.license_terms="https://jfrog.com/platform/enterprise-plus-eula/"
 
-ARG RABBITMQ_VERSION=3.8.9
+ARG RABBITMQ_VERSION=3.8.9-debian-10-r88
 
 LABEL io.k8s.description="Lightweight open source message broker" \
     io.k8s.display-name="RabbitMQ" \
@@ -23,10 +31,9 @@ LABEL io.k8s.description="Lightweight open source message broker" \
 RUN yum install -y --disableplugin=subscription-manager -y openssl curl ca-certificates fontconfig gzip glibc-langpack-en tar \
     && yum  -y --disableplugin=subscription-manager update; yum --disableplugin=subscription-manager clean all
 
-
 ENV GPG_KEY="0A9AF2115F4687BD29803A206B73A36E6026DFCA" \
-    HOME=/opt/bitnami/rabbitmq/.rabbitmq  \
-    RABBITMQ_HOME=/opt/bitnami \
+    HOME=/var/lib/rabbitmq \
+    RABBITMQ_HOME=/opt/rabbitmq \
     RABBITMQ_LOGS=- \
     RABBITMQ_SASL_LOGS=- \
     LANG=en_US.UTF-8 \
@@ -44,11 +51,15 @@ RUN set -xe && \
 
 # COPY OVER THE RABBITMQ LICENSES INTO THE FOLDER FOR REDHAT TO SCAN
 COPY --from=base /opt/bitnami /opt/bitnami
-COPY xray-rabbitmq-setup.sh /opt/bitnami/scripts/rabbitmq/setup.sh
-RUN mkdir -p /licenses && chmod 0755 /licenses && cp -rf /opt/bitnami/rabbitmq/licenses/* /licenses && chmod 0755 /opt/bitnami/scripts/rabbitmq/setup.sh
-RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq/ && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq
+
+RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq
 RUN mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log
-RUN mkdir -p /bitnami && chmod -R 0777 /bitnami
+RUN mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && chown -R 1000721001:1000721001 	/var/lib/rabbitmq
+RUN mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq
+RUN mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami
+RUN mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses
+RUN mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses
+RUN mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
 
 ENV BITNAMI_APP_NAME="rabbitmq" \
     LANG="en_US.UTF-8" \
@@ -58,6 +69,5 @@ EXPOSE 4369 5672 15672 25672
 
 USER 1000721001
 ENV PATH=/opt/bitnami/rabbitmq/sbin:$PATH
-RUN mkdir -p /opt/bitnami/rabbitmq/test
 ENTRYPOINT [ "/opt/bitnami/scripts/rabbitmq/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/rabbitmq/run.sh" ]

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -2,7 +2,7 @@
 # https://github.com/bitnami/bitnami-docker-rabbitmq/blob/master/3.8/debian-10/Dockerfile
 # JFROG REDHAT UBI PORT TO WORK IN BITNAMI RABBITMQ HELM CHARTS
 
-FROM bitnami/rabbitmq:3.8.3-debian-10-r40 as base
+FROM bitnami/rabbitmq:3.8.9-debian-10-r20 as base
 
 FROM registry.access.redhat.com/ubi8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -12,7 +12,7 @@ LABEL name="JFrog Rabbit MQ" \
       summary="JFrog Rabbit MQ (Red Hat UBI)" \
       com.jfrog.license_terms="https://jfrog.com/platform/enterprise-plus-eula/"
 
-ARG RABBITMQ_VERSION=3.8.3
+ARG RABBITMQ_VERSION=3.8.9
 
 LABEL io.k8s.description="Lightweight open source message broker" \
     io.k8s.display-name="RabbitMQ" \
@@ -44,11 +44,12 @@ RUN set -xe && \
 
 # COPY OVER THE RABBITMQ LICENSES INTO THE FOLDER FOR REDHAT TO SCAN
 COPY --from=base /opt/bitnami /opt/bitnami
-RUN mkdir -p /licenses && chmod 0755 /licenses && cp -rf /opt/bitnami/rabbitmq/licenses/* /licenses
-
+COPY xray-rabbitmq-setup.sh /opt/bitnami/scripts/rabbitmq/setup.sh
+RUN mkdir -p /licenses && chmod 0755 /licenses && cp -rf /opt/bitnami/rabbitmq/licenses/* /licenses && chmod 0755 /opt/bitnami/scripts/rabbitmq/setup.sh
 RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq/ && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq
 RUN mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log
 RUN mkdir -p /bitnami && chmod -R 0777 /bitnami
+
 ENV BITNAMI_APP_NAME="rabbitmq" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en"

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -25,8 +25,8 @@ RUN yum install -y --disableplugin=subscription-manager -y openssl curl ca-certi
 
 
 ENV GPG_KEY="0A9AF2115F4687BD29803A206B73A36E6026DFCA" \
-    HOME=/var/lib/rabbitmq \
-    RABBITMQ_HOME=/opt/rabbitmq \
+    HOME=/opt/bitnami/rabbitmq  \
+    RABBITMQ_HOME=/opt/bitnami \
     RABBITMQ_LOGS=- \
     RABBITMQ_SASL_LOGS=- \
     LANG=en_US.UTF-8 \

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -53,7 +53,7 @@ RUN mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && 
 RUN mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq
 RUN mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami
 RUN mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses
-RUN mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses
+RUN mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses && cp -rf /opt/bitnami/rabbitmq/licenses/* /licenses && chmod 0777 /opt/bitnami/scripts/rabbitmq/setup.sh
 RUN mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
 
 ENV BITNAMI_APP_NAME="rabbitmq" \

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -25,7 +25,7 @@ RUN yum install -y --disableplugin=subscription-manager -y openssl curl ca-certi
 
 
 ENV GPG_KEY="0A9AF2115F4687BD29803A206B73A36E6026DFCA" \
-    HOME=/opt/bitnami/rabbitmq  \
+    HOME=/opt/bitnami/rabbitmq/.rabbitmq  \
     RABBITMQ_HOME=/opt/bitnami \
     RABBITMQ_LOGS=- \
     RABBITMQ_SASL_LOGS=- \

--- a/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
+++ b/customize-example/Dockerfile.redhat-ubi-jfrog-rabbitmq
@@ -8,6 +8,7 @@ FROM bitnami/rabbitmq:3.8.9-debian-10-r88 as base
 FROM registry.access.redhat.com/ubi8
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
 LABEL name="JFrog Rabbit MQ" \
       description="JFrog Rabbit MQ image based on the Red Hat Universal Base Image." \
       vendor="JFrog" \
@@ -46,14 +47,14 @@ RUN set -xe && \
 # COPY OVER THE RABBITMQ LICENSES INTO THE FOLDER FOR REDHAT TO SCAN
 COPY --from=base /opt/bitnami /opt/bitnami
 
-RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq  \
-   && mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log  \
-   && mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && chown -R 1000721001:1000721001 	/var/lib/rabbitmq \
-   && mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq    \
-   && mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami     \
-   && mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses    \
-   && mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses  \
-   && mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
+RUN mkdir -p /opt/bitnami/rabbitmq/ && chown -R 0777 /opt/bitnami/rabbitmq && chown -R 1000721001:1000721001 /opt/bitnami/rabbitmq
+RUN mkdir -p /var/log/rabbitmq/log/ && chmod -R 0777 /var/log
+RUN mkdir -p /var/lib/rabbitmq					 && chmod -R 0777 /var/lib/rabbitmq				   && chown -R 1000721001:1000721001 	/var/lib/rabbitmq
+RUN mkdir -p /opt/rabbitmq                       && chmod -R 0777 /opt/rabbitmq                    && chown -R 1000721001:1000721001    /opt/rabbitmq
+RUN mkdir -p /opt/bitnami                        && chmod -R 0777 /opt/bitnami                     && chown -R 1000721001:1000721001    /opt/bitnami
+RUN mkdir -p /licenses                           && chmod -R 0777 /licenses                        && chown -R 1000721001:1000721001    /licenses
+RUN mkdir -p /opt/bitnami/rabbitmq/licenses      && chmod -R 0777 /opt/bitnami/rabbitmq/licenses   && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/licenses
+RUN mkdir -p /opt/bitnami/rabbitmq/test          && chmod -R 0777 /opt/bitnami/rabbitmq/test       && chown -R 1000721001:1000721001    /opt/bitnami/rabbitmq/test
 
 ENV BITNAMI_APP_NAME="rabbitmq" \
     LANG="en_US.UTF-8" \

--- a/customize-example/Dockerfile.redhat-ubi-rt7
+++ b/customize-example/Dockerfile.redhat-ubi-rt7
@@ -51,7 +51,7 @@ RUN useradd -M -s /usr/sbin/nologin --uid ${ARTIFACTORY_USER_ID} --user-group ${
 
 # Add RUN instruction for updating the vulnerability found in openssl-libs package.
 
-RUN yum  update openssl-libs
+RUN yum  update openssl-libs -y 
 
 
 USER $JF_ARTIFACTORY_USER

--- a/customize-example/Dockerfile.redhat-ubi-rt7
+++ b/customize-example/Dockerfile.redhat-ubi-rt7
@@ -49,6 +49,10 @@ RUN useradd -M -s /usr/sbin/nologin --uid ${ARTIFACTORY_USER_ID} --user-group ${
     yum install -y --disableplugin=subscription-manager net-tools && \
     yum install -y --disableplugin=subscription-manager hostname
 
+# Add RUN instruction for updating the vulnerability found in openssl-libs package.
+
+RUN microdnf update openssl-libs
+
 
 USER $JF_ARTIFACTORY_USER
 

--- a/customize-example/Dockerfile.redhat-ubi-rt7
+++ b/customize-example/Dockerfile.redhat-ubi-rt7
@@ -7,7 +7,7 @@ ARG ARTIFACTORY_BASE_VERSION
 FROM docker.bintray.io/jfrog/artifactory-pro:${ARTIFACTORY_BASE_VERSION} AS base
 
 # The new image based on registry.access.redhat.com/ubi
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 LABEL name="JFrog Artifactory Pro" \
       description="JFrog Artifactory Pro image based on the Red Hat Universal Base Image." \

--- a/customize-example/Dockerfile.redhat-ubi-rt7
+++ b/customize-example/Dockerfile.redhat-ubi-rt7
@@ -7,7 +7,7 @@ ARG ARTIFACTORY_BASE_VERSION
 FROM docker.bintray.io/jfrog/artifactory-pro:${ARTIFACTORY_BASE_VERSION} AS base
 
 # The new image based on registry.access.redhat.com/ubi
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8
 
 LABEL name="JFrog Artifactory Pro" \
       description="JFrog Artifactory Pro image based on the Red Hat Universal Base Image." \
@@ -51,7 +51,7 @@ RUN useradd -M -s /usr/sbin/nologin --uid ${ARTIFACTORY_USER_ID} --user-group ${
 
 # Add RUN instruction for updating the vulnerability found in openssl-libs package.
 
-RUN microdnf update openssl-libs
+RUN yum  update openssl-libs
 
 
 USER $JF_ARTIFACTORY_USER

--- a/customize-example/Dockerfile.redhat-ubi-xray-analysis
+++ b/customize-example/Dockerfile.redhat-ubi-xray-analysis
@@ -22,7 +22,7 @@ ENV JF_XRAY_USER=xray \
 
 COPY --from=base /opt/jfrog/xray /opt/jfrog/xray
 COPY --from=base /var/opt/jfrog/xray /var/opt/jfrog/xray
-COPY --from=base /postgresql-client /postgresql-client
+#COPY --from=base /postgresql-client /postgresql-client
 
 # Add license information to meet the Red Hat container image certification requirements
 COPY --from=base /opt/jfrog/xray/app/doc/* /licenses/

--- a/customize-example/Dockerfile.redhat-ubi-xray-analysis
+++ b/customize-example/Dockerfile.redhat-ubi-xray-analysis
@@ -30,7 +30,7 @@ COPY --from=base /opt/jfrog/xray/app/doc/* /licenses/
 RUN mkdir -p /var/opt/jfrog && chmod 0777 /var/opt/jfrog
 
 RUN useradd -M -s /usr/sbin/nologin --uid ${XRAY_USER_ID} --user-group ${JF_XRAY_USER} && \
-    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL} /postgresql-client && \
+    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL}  && \
     yum install -y --disableplugin=subscription-manager wget && \
     yum install -y --disableplugin=subscription-manager procps && \
     yum install -y --disableplugin=subscription-manager net-tools && \

--- a/customize-example/Dockerfile.redhat-ubi-xray-indexer
+++ b/customize-example/Dockerfile.redhat-ubi-xray-indexer
@@ -30,7 +30,7 @@ RUN mkdir -p /var/opt/jfrog && chmod 0777 /var/opt/jfrog
 
 
 RUN useradd -M -s /usr/sbin/nologin --uid ${XRAY_USER_ID} --user-group ${JF_XRAY_USER} && \
-    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL} /postgresql-client && \
+    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL}  && \
     yum install -y --disableplugin=subscription-manager wget && \
     yum install -y --disableplugin=subscription-manager procps && \
     yum install -y --disableplugin=subscription-manager net-tools && \

--- a/customize-example/Dockerfile.redhat-ubi-xray-indexer
+++ b/customize-example/Dockerfile.redhat-ubi-xray-indexer
@@ -21,7 +21,7 @@ ENV JF_XRAY_USER=xray \
 
 COPY --from=base /opt/jfrog/xray /opt/jfrog/xray
 COPY --from=base /var/opt/jfrog/xray /var/opt/jfrog/xray
-COPY --from=base /postgresql-client /postgresql-client
+#COPY --from=base /postgresql-client /postgresql-client
 
 # Add license information to meet the Red Hat container image certification requirements
 COPY --from=base /opt/jfrog/xray/app/doc/* /licenses/

--- a/customize-example/Dockerfile.redhat-ubi-xray-persist
+++ b/customize-example/Dockerfile.redhat-ubi-xray-persist
@@ -30,7 +30,7 @@ RUN mkdir -p /var/opt/jfrog && chmod 0777 /var/opt/jfrog
 
 
 RUN useradd -M -s /usr/sbin/nologin --uid ${XRAY_USER_ID} --user-group ${JF_XRAY_USER} && \
-    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL} /postgresql-client && \
+    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL}  && \
     yum install -y --disableplugin=subscription-manager wget && \
     yum install -y --disableplugin=subscription-manager procps && \
     yum install -y --disableplugin=subscription-manager net-tools && \

--- a/customize-example/Dockerfile.redhat-ubi-xray-persist
+++ b/customize-example/Dockerfile.redhat-ubi-xray-persist
@@ -21,7 +21,7 @@ ENV JF_XRAY_USER=xray \
 
 COPY --from=base /opt/jfrog/xray /opt/jfrog/xray
 COPY --from=base /var/opt/jfrog/xray /var/opt/jfrog/xray
-COPY --from=base /postgresql-client /postgresql-client
+#COPY --from=base /postgresql-client /postgresql-client
 
 # Add license information to meet the Red Hat container image certification requirements
 COPY --from=base /opt/jfrog/xray/app/doc/* /licenses/

--- a/customize-example/Dockerfile.redhat-ubi-xray-server
+++ b/customize-example/Dockerfile.redhat-ubi-xray-server
@@ -33,7 +33,7 @@ RUN mkdir -p /var/opt/jfrog && chmod 0777 /var/opt/jfrog
 
 
 RUN useradd -M -s /usr/sbin/nologin --uid ${XRAY_USER_ID} --user-group ${JF_XRAY_USER} && \
-    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL} /postgresql-client && \
+    chown -R ${JF_XRAY_USER}:${JF_XRAY_USER} ${JF_PRODUCT_HOME} ${JF_PRODUCT_DATA_INTERNAL}  && \
     yum install -y --disableplugin=subscription-manager wget && \
     yum install -y --disableplugin=subscription-manager procps && \
     yum install -y --disableplugin=subscription-manager net-tools && \

--- a/customize-example/Dockerfile.redhat-ubi-xray-server
+++ b/customize-example/Dockerfile.redhat-ubi-xray-server
@@ -21,7 +21,7 @@ ENV JF_XRAY_USER=xray \
 
 COPY --from=base /opt/jfrog/xray /opt/jfrog/xray
 COPY --from=base /var/opt/jfrog/xray /var/opt/jfrog/xray
-COPY --from=base /postgresql-client /postgresql-client
+#COPY --from=base /postgresql-client /postgresql-client
 
 # Add license information to meet the Red Hat container image certification requirements
 COPY --from=base /opt/jfrog/xray/app/doc/* /licenses/

--- a/customize-example/xray-rabbitmq-setup.sh
+++ b/customize-example/xray-rabbitmq-setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace
+
+# Load libraries
+. /opt/bitnami/scripts/libos.sh
+. /opt/bitnami/scripts/librabbitmq.sh
+
+# Load RabbitMQ environment variables
+eval "$(rabbitmq_env)"
+
+# Ensure RabbitMQ environment variables settings are valid
+rabbitmq_validate
+# Ensure RabbitMQ is stopped when this script ends.
+trap "rabbitmq_stop" EXIT
+# Ensure 'daemon' user exists when running as 'root'
+am_i_root && ensure_user_exists "$RABBITMQ_DAEMON_USER" "$RABBITMQ_DAEMON_GROUP"
+# Ensure RabbitMQ is initialized
+rabbitmq_initialize
+
+USERS=$(rabbitmqctl list_users)
+if [[ "$USERS" =~ (xray) ]]
+then
+    rabbitmqctl authenticate_user xray xray
+else
+    rabbitmqctl add_user xray xray
+fi
+rabbitmqctl set_user_tags xray administrator
+rabbitmqctl set_permissions -p / xray ".*" ".*" ".*"


### PR DESCRIPTION
Updates for Openshift Xray helm chart to use rabbitmq vs deprecated rabbitmq-ha helm chart. Updating bitnami image to latest v3.8.9 and including xray user fix due to auth issue w/ chart and UBI8 image.